### PR TITLE
Add jump-hosts support

### DIFF
--- a/profiles.clj
+++ b/profiles.clj
@@ -1,13 +1,13 @@
 {:dev {:dependencies [[ch.qos.logback/logback-classic "1.1.1"]
-                      [org.slf4j/jcl-over-slf4j "1.7.6"]]
+                      [org.slf4j/jcl-over-slf4j "1.7.6"]
+                      [com.palletops/crates "0.1.2-SNAPSHOT"]]
        :checkout-deps-shares ^:replace [:source-paths :test-paths
                                         :compile-path]
        :plugins [[codox/codox.leiningen "0.6.4"]
                  [lein-marginalia "0.7.1"]
-                 [lein-pallet-release "RELEASE"]]
-       :pallet-release
-       {:url "https://pbors:${GH_TOKEN}@github.com/pallet/pallet-aws.git",
-        :branch "master"}}
+                 [lein-pallet-release "RELEASE"]
+                 [com.palletops/lein-test-env "RELEASE"]]}
+ :provided {:dependencies [[com.palletops/pallet "0.8.0-RC.9"]]}
  :doc {:dependencies [[com.palletops/pallet-codox "0.1.0"]]
        :codox {:writer codox-md.writer/write-docs
                :output-dir "doc/0.1/api"
@@ -16,9 +16,9 @@
        :aliases {"marg" ["marg" "-d" "doc/0.1/"]
                  "codox" ["doc"]
                  "doc" ["do" "codox," "marg"]}}
- :release
- {:set-version
-  {:updates [{:path "README.md" :no-snapshot true}]}}
  :no-checkouts {:checkout-shares ^:replace []} ; disable checkouts
  :clojure-1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
- :clojure-1.6 {:dependencies [[org.clojure/clojure "1.6.0-RC.1"]]}}
+ :clojure-1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
+ :aws {:pallet/test-env {:test-specs [{:selector :amzn-linux-2013-092}]}
+       ;; :dependencies [[com.palletops/pallet-aws "0.2.4-SNAPSHOT"]]
+       }}

--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,8 @@
   :url "http://palletops.com"
   :license {:name "All rights reserved"}
   :scm {:url "git@github.com:pallet/pallet-aws.git"}
-  :dependencies [[com.palletops/pallet-aws-ops "0.2.0"
+  :dependencies [[com.palletops/pallet-aws-ops "0.2.1-SNAPSHOT"
                   :exclusions [commons-logging]]
-                 [com.palletops/pallet "0.8.0-RC.9"]
                  [org.clojure/core.match "0.2.0"
-                  :exclusions [org.clojure/clojure]]])
+                  :exclusions [org.clojure/clojure]]
+                 [prismatic/schema "0.2.1"]])

--- a/test/pallet/compute/ec2/support_test.clj
+++ b/test/pallet/compute/ec2/support_test.clj
@@ -1,0 +1,17 @@
+(ns pallet.compute.ec2.support-test
+  (:require
+   [clojure.core.async :refer [<!! chan]]
+   [clojure.test :refer :all]
+   [com.palletops.aws.api :as api]
+   [com.palletops.aws.vpc :refer :all]
+   [pallet.compute :refer [nodes]]
+   [pallet.crates.test-nodes :as test-nodes]
+   [pallet.test-env
+    :refer [*compute-service* *node-spec-meta* test-env]]
+   [pallet.test-env.project :as project]))
+
+(test-env test-nodes/node-specs project/project)
+
+(deftest ^:support nodes-test
+  (let [{:keys [credentials] :as props} (service-properties *compute-service*)]
+    (is (nodes *compute-service*))))


### PR DESCRIPTION
This adds support at the service provider level for the specification of
a sequence of hosts to use to access the nodes within the compute
service.
