### PR TITLE
Omit top-level sg from VPC launch-options

### DIFF
--- a/src/pallet/compute/ec2.clj
+++ b/src/pallet/compute/ec2.clj
@@ -290,7 +290,11 @@
        :min-count node-count
        :max-count node-count
        :key-name key-name
-       :security-groups [security-group]}
+       }
+      (maybe-assoc
+       :security-groups
+       (when-not (-> node-spec :provider :pallet-ec2 :network-interfaces)
+         [security-group]))
       (maybe-assoc :placement placement)
       (maybe-assoc :instance-type (-> node-spec :hardware :hardware-id))))))
 

--- a/test/pallet/compute/ec2_test.clj
+++ b/test/pallet/compute/ec2_test.clj
@@ -58,7 +58,31 @@
                         {:block-device-mapping
                          [{:device-name "/dev/sdh"}]}}))
           "sg" "kn"))
-      "block-device-mapping"))
+      "block-device-mapping")
+  (is (= {:key-name "kn",
+          :max-count 1,
+          :min-count 1,
+          :image-id "i"
+          :network-interfaces [{:device-index 0
+                                :subnet-id "subnet-abcdef77"
+                                :groups ["sg-abcdef88"]
+                                :associate-public-ip-address true
+                                :delete-on-termination true}]}
+         (launch-options
+          1
+          (group-spec :gn
+            :node-spec
+            (node-spec
+             :image {:image-id "i"}
+             :provider {:pallet-ec2
+                        {:network-interfaces
+                         [{:device-index 0
+                                :subnet-id "subnet-abcdef77"
+                                :groups ["sg-abcdef88"]
+                                :associate-public-ip-address true
+                                :delete-on-termination true}]}}))
+          "sg" "kn"))
+      "network-interfaces"))
 
 (deftest instance-tags-test
   (is (= [{:key "pallet-group", :value "abcd"}


### PR DESCRIPTION
If an instance is placed in a VPC by providing :network-interfaces
options then the top-level security group name munged from the
pallet group name must not be used, or the AWS API will throw an
Exception.

This commit omits the :security-groups key from launch-options
when the node-spec has a [:provider :pallet-ec2 :network-interfaces]
key.

The problem is described in more detail with stacktraces here :

https://groups.google.com/forum/#!topic/pallet-clj/sWu-4IanCW0
